### PR TITLE
Functional dex from install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+
+build:
+	snapcraft cleanbuild
+
+clean:
+	rm dex_*
+

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,9 @@ web:
   # tlsCert: /etc/dex/tls.crt
   # tlsKey: /etc/dex/tls.key
 
+frontend:
+  dir: /var/snap/dex/current/web
+
 # Uncomment this block to enable the gRPC API. This values MUST be different
 # from the HTTP endpoints.
 # grpc:

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Executes on 'install', 'upgrade', and 'configure' steps
+
+echo "Copying web templates to ${SNAP_DATA}"
+cp -r ${SNAP}/web ${SNAP_DATA}/web

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
  while the actual authentication is performed by established user
  management systems such as Google, GitHub, FreeIPA, etc.
 grade: devel
-confinement: devmode
+confinement: strict
 
 apps:
     dex:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,8 +47,9 @@ parts:
         export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
         go get github.com/coreos/dex
         cd src/github.com/coreos/dex && make
-        cp bin/dex ../../../../bin/dex
+        cp bin/dex ../../../../
         cp bin/example-app ../../../../
+        cp -r web ../../../../
         rm -rf src pkg
         rm -f go1.7.4.linux-amd64.tar.gz
   daemon:


### PR DESCRIPTION
Edits to make the web directory exist on install

This last bit makes snap install dex --dangerous --devmode functional
with a daemon + exampleapp in the snap. Precursor work to enable
enhanced functionality from the dex charm.