### PR TITLE
Lock the go get command to 2.4.x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ parts:
         export GOPATH=$PWD
         export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
         go get github.com/coreos/dex
-        cd src/github.com/coreos/dex && make
+        cd src/github.com/coreos/dex && git checkout v2.4.0 && make
         cp bin/dex ../../../../
         cp bin/example-app ../../../../
         cp -r web ../../../../


### PR DESCRIPTION
There may be a better way to do this and i'm fully open to suggestions on how to clean this up.

At present if you build from master, it complains about missing connector for "local", what I failed to realize is the go get command was fetching directly from tip of master. Thats not going to reliably deliver 2.4.x in the snap when you rebuild and will surface one off errors.

This keeps the build of the release at 2.4.0 in a hard-coded path.